### PR TITLE
add time offset tag names

### DIFF
--- a/lib/src/tags.dart
+++ b/lib/src/tags.dart
@@ -254,6 +254,9 @@ class StandardTags extends TagsBase {
     0x9000: _withFunc('ExifVersion', makeString),
     0x9003: _make('DateTimeOriginal'),
     0x9004: _make('DateTimeDigitized'),
+    0x9010: _make('OffsetTime'),
+    0x9011: _make('OffsetTimeOriginal'),
+    0x9012: _make('OffsetTimeDigitized'),
     0x9101: _withMap('ComponentsConfiguration', const {
       0: '',
       1: 'Y',


### PR DESCRIPTION
Exif 2.31 introduced time offset tags: https://en.wikipedia.org/wiki/Exif#Technical_2

This patch adds human-readable tag names according to https://www.exiv2.org/tags.html