### PR TITLE
Bump `sprintf` to 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.3
+
+- Bump dependency `sprintf` to `7.0.0`
+
 ## 3.1.2
 
 - Fix Bad state: No element while reading Exif

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: exif
-version: 3.1.2
+version: 3.1.3
 description: >-
   Decode Exif metadata from digital image files.
   Supported formats: tiff, jpeg, HEIC

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   collection: ^1.15.0
   convert: ^3.0.0
   json_annotation: ^4.3.0
-  sprintf: ^6.0.0
+  sprintf: ^7.0.0
 dev_dependencies:
   archive: ^3.1.2
   build_runner: ^2.1.4


### PR DESCRIPTION
Bumps dependency `sprintf` to version 7.0.0.

The `sprintf` change should not affect this implementation:
https://pub.flutter-io.cn/packages/sprintf/changelog

Fixes #38